### PR TITLE
Add shoulda-context and example tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,5 +52,7 @@ group :test do
   gem 'cucumber-rails', :require => false
   # database_cleaner is not required, but highly recommended
   gem 'database_cleaner'
+
+  gem 'shoulda-context'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ~/Documents/github/knapsack-pro/knapsack
   specs:
-    knapsack (1.6.0)
+    knapsack (1.7.0)
       rake
       timecop (>= 0.1.0)
 
@@ -171,6 +171,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    shoulda-context (1.2.1)
     slop (3.6.0)
     spring (1.3.6)
     sprockets (3.5.2)
@@ -184,7 +185,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
-    timecop (0.8.0)
+    timecop (0.8.1)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -216,6 +217,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shoulda-context
   spring
   sqlite3
   turbolinks
@@ -223,4 +225,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/test/shoulda_context/calculator_test.rb
+++ b/test/shoulda_context/calculator_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class Calculator
+  def sum(x, y)
+    x + y
+  end
+
+  def product(x, y)
+    x * y
+  end
+end
+
+class CalculatorTest < ActiveSupport::TestCase
+  context "a calculator" do
+    setup do
+      @calculator = Calculator.new
+    end
+
+    should "add two numbers for the sum" do
+      assert_equal 4, @calculator.sum(2, 2)
+    end
+
+    should "multiply two numbers for the product" do
+      assert_equal 10, @calculator.product(2, 5)
+    end
+  end
+end


### PR DESCRIPTION
Related PR
https://github.com/ArturT/knapsack/pull/37

This PR is using knapsack gem on CI based on the branch: https://github.com/ArturT/knapsack/tree/shoulda-context

How to test if knapsack support for shoulda-context works? Please generate report with

```
KNAPSACK_GENERATE_REPORT=true bundle exec rake test
```

The result reports should not contain the wrong path like
 `/Users/artur/.rvm/gems/ruby-2.3.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb`

Correct expected path is `test/shoulda_context/calculator_test.rb`

Example output for generated report:

```
{
  "test/minitest_duplicated/meme_unit_test.rb": 0.00022482872009277344,
  "/Users/artur/.rvm/gems/ruby-2.3.0/gems/shoulda-context-1.2.1/lib/shoulda/context/context.rb": 0.0001289844512939453,
  "test/minitest/meme_spec_test.rb": 7.867813110351562e-05,
  "test/minitest_duplicated/meme_spec_test.rb": 0.00011181831359863281,
  "test/controllers/articles_controller_test.rb": 0.4389979839324951,
  "test/models/article_test.rb": 2.6226043701171875e-05,
  "test/controllers/welcome_controller_test.rb": 0.012137889862060547
}
```

If you want to test knapsack gem from you local repo then update Gemfile and use your own path.

```
gem 'knapsack', path: ENV['KNAPSACK_REPO_PATH'] || '~/Documents/github/knapsack-pro/knapsack'
```
